### PR TITLE
fix(config): use ckb_dev chain name in dev.toml

### DIFF
--- a/ckb/devnet/specs/dev.toml
+++ b/ckb/devnet/specs/dev.toml
@@ -1,4 +1,4 @@
-name = "offckb"
+name = "ckb_dev"
 
 [genesis]
 version = 0


### PR DESCRIPTION
the devnet uses a special name `offckb` by default which turns out are incompatible with tools like `ckb-cli`
```sh
$ ./ckb-cli --url http://localhost:9000/ util cell-meta --tx-hash 0x4660f484fe2e3db4c8acb92e3be5592735b6ac6edcebbff815b2b203039bb8d7 --index 0
Unexpected network type: offckb
```

see: 
- https://github.com/ckb-ecofund/offckb/issues/144